### PR TITLE
Add fasting upgrades and compact UI

### DIFF
--- a/Universal Psychology/style.css
+++ b/Universal Psychology/style.css
@@ -171,18 +171,18 @@ body {
 /* General Styling for <section> elements */
 section {
     background-color: #f9f9f9;
-    padding: 15px;
+    padding: 10px;
     border-radius: 5px;
     border: 1px solid #ddd;
-    flex-shrink: 0; 
+    flex-shrink: 0;
 }
 
 /* General H2 styling within sections */
 section h2 {
     margin-top: 0;
-    margin-bottom: 10px;
+    margin-bottom: 8px;
     color: #007bff;
-    font-size: 1.2em; 
+    font-size: 1em;
 }
 
 
@@ -212,7 +212,7 @@ section h2 {
 
 /* Upgrade Items */
 .upgrade-item {
-    padding: 10px;
+    padding: 8px;
     border: 1px solid #eee;
     margin-bottom: 8px;
     border-radius: 4px;
@@ -220,18 +220,18 @@ section h2 {
 }
 .upgrade-item h3 {
     margin-top: 0;
-    margin-bottom: 5px;
-    font-size: 1.1em;
+    margin-bottom: 4px;
+    font-size: 1em;
 }
 .upgrade-item p {
-    margin: 0 0 8px 0;
-    font-size: 0.9em;
-    line-height: 1.3;
+    margin: 0 0 6px 0;
+    font-size: 0.85em;
+    line-height: 1.2;
 }
-.upgrade-item button { 
-    font-size: 0.9em;
-    padding: 5px 10px;
-    background-color: #28a745; 
+.upgrade-item button {
+    font-size: 0.85em;
+    padding: 4px 8px;
+    background-color: #28a745;
 }
 .upgrade-item button:hover {
     background-color: #218838;
@@ -243,7 +243,7 @@ section h2 {
 }
 
 .project-item {
-    padding: 10px;
+    padding: 8px;
     border: 1px solid #ccd;
     margin-bottom: 8px;
     border-radius: 4px;
@@ -251,15 +251,15 @@ section h2 {
 }
 .project-item h3 {
     margin-top: 0;
-    margin-bottom: 5px;
-    font-size: 1.1em;
+    margin-bottom: 4px;
+    font-size: 1em;
 }
 .project-item p {
     margin: 0 0 8px 0;
 }
 .project-item button {
-    font-size: 0.9em;
-    padding: 5px 10px;
+    font-size: 0.85em;
+    padding: 4px 8px;
     background-color: #007bff;
 }
 .project-item button:disabled {


### PR DESCRIPTION
## Summary
- implement auto-purchasing fuel via new `intermittentFasting` upgrade
- add `metabolicEfficiency2` upgrade gated by brain level 3
- trigger irregular snack auto-buying at brain level 3
- support `brainRequirement` for upgrades
- shrink section padding and text sizes for a tighter layout

## Testing
- `node --check "Universal Psychology/game_logic.js"`
- `node --check "Universal Psychology/three_scene.js"`


------
https://chatgpt.com/codex/tasks/task_e_6852279f9acc832781362dc2c570d6cb