### PR TITLE
Enhance new game defaults and help

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -3,7 +3,7 @@
 document.addEventListener('DOMContentLoaded', async () => {
     // --- 1. GAME STATE OBJECT ---
     const gameState = {
-        neurons: 0,
+        neurons: 50,
         psychbucks: 50,
         neuronsPerClick: 1,
         currentBrainLevel: 0,
@@ -555,6 +555,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         UIManager.updateFactoryDisplay();
         UIManager.updateNeuroFuelDisplay();
         UIManager.updateAllDisplays();
+        if (instructionsOverlayDOM) instructionsOverlayDOM.style.display = 'flex';
         UIManager.logMessage("Welcome to Universal Psychology!", "log-info");
         setInterval(gameLoop, 1000);
         setInterval(() => saveGame(currentSaveSlot), AUTO_SAVE_INTERVAL);

--- a/Universal Psychology/index.html
+++ b/Universal Psychology/index.html
@@ -133,8 +133,9 @@
         <div id="instructions-overlay">
             <div id="instructions-content">
                 <h2>How to Play</h2>
+                <p>Your goal is to produce as many neurons as possible and use them to build a bigger, better brain.</p>
                 <p>Click <strong>Add Neurons</strong> to gain neurons or build proliferation factories for passive income.</p>
-                <p>Spend neurons to buy upgrades. These unlock new features and improve production.</p>
+                <p>Spend neurons to buy upgrades that unlock new features and improve production.</p>
                 <p><strong>Psychbucks</strong> accumulate from proliferation factories and projects. Use them for advanced upgrades.</p>
                 <p>Manual neuron generation consumes <strong>Fuel</strong>. Purchase food to refill it.</p>
                 <button id="close-instructions">Close</button>


### PR DESCRIPTION
## Summary
- start new games with 50 neurons
- show the help overlay when a game loads
- expand the help text with clearer instructions

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68523001e5048327b0facedeb6ac3bf0