### PR TITLE
Speed up question reload

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -75,6 +75,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const ANXIETY_THRESHOLD = 70; const ANXIETY_SUSTAINED_THRESHOLD = 60; const ANXIETY_TIME_LIMIT = 20; const MAX_ANXIETY = 100;
     const SCARY_STIMULI_INTERVAL_MS = 120000; const BASE_IQ = 80; const IQ_SCALE_FACTOR = 15; const MAX_LOG_MESSAGES = 20; const FACTORY_PRODUCTION_RATE = 0.5;
     const OPS_PER_NEURON = 0.01; const AUTO_SAVE_INTERVAL = 10000;
+    const QUESTION_RELOAD_DELAY_MS = 0; // time before next question loads
     const FOOD_OPTIONS = [
         {emoji: '🍌', name: 'Banana', fuel: 10},
         {emoji: '🥪', name: 'Sandwich', fuel: 20},
@@ -234,7 +235,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     AnxietySystem.increaseMeter(anxietyIncrease);
                 }
             }
-            this.currentQuestionIndex = -1; setTimeout(() => { this.loadNextQuestion(); UIManager.updateAllDisplays(); }, 1800);
+            this.currentQuestionIndex = -1; setTimeout(() => { this.loadNextQuestion(); UIManager.updateAllDisplays(); }, QUESTION_RELOAD_DELAY_MS);
         }
     };
 


### PR DESCRIPTION
## Summary
- add `QUESTION_RELOAD_DELAY_MS` constant
- use this constant to reload questions without delay

## Testing
- `node --check "Universal Psychology/game_logic.js"`

------
https://chatgpt.com/codex/tasks/task_e_68523032d2c08327830c35abedb4d6c4