### PR TITLE
Improve brain upgrade animation

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -199,7 +199,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const dy=(Math.random()-0.5)*300;
                 requestAnimationFrame(()=>{p.style.transform=`translate(${dx}px, ${dy}px)`;p.style.opacity="0";});
             }
-            setTimeout(()=>{overlay.innerHTML="";},1500);
+            setTimeout(()=>{overlay.innerHTML="";},2000);
         },
     };
 

--- a/Universal Psychology/style.css
+++ b/Universal Psychology/style.css
@@ -469,14 +469,23 @@ button:hover {
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%) scale(0.5);
-    width: 200px;
+    width: 300px;
     height: auto;
-    animation: upgrade-spin-fade 1.5s ease-out forwards;
+    transform-origin: center;
+    animation: upgrade-spin-fade 2s ease-out forwards;
 }
 
 @keyframes upgrade-spin-fade {
-    to {
-        transform: translate(-50%, -50%) scale(2) rotate(360deg);
+    0% {
+        transform: translate(-50%, -50%) scale(0.5) rotate(0deg);
+        opacity: 1;
+    }
+    80% {
+        transform: translate(-50%, -50%) scale(3) rotate(720deg);
+        opacity: 1;
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(3) rotate(720deg);
         opacity: 0;
     }
 }


### PR DESCRIPTION
## Summary
- make upgrade animation image bigger and rotate from center
- increase animation duration and spins, remove after 2s

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68523959be2083279706aa74ede3d753