### PR TITLE
Add start control and exponential scoring to NeuroSnake

### DIFF
--- a/Universal Psychology/index.html
+++ b/Universal Psychology/index.html
@@ -139,7 +139,9 @@
     <!-- NeuroSnake Popup -->
         <div id="neurosnake-popup" class="popup-overlay">
             <div id="neurosnake-content">
+                <div id="neurosnake-score">Psychbucks: 0</div>
                 <canvas id="neurosnake-canvas" width="400" height="400"></canvas>
+                <p id="neurosnake-instruction">Press an arrow key to start</p>
                 <button id="close-neurosnake">Close</button>
             </div>
         </div>

--- a/Universal Psychology/style.css
+++ b/Universal Psychology/style.css
@@ -472,6 +472,16 @@ button:hover {
     padding: 20px;
     border-radius: 8px;
 }
+#neurosnake-score {
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 10px;
+}
+#neurosnake-instruction {
+    text-align: center;
+    margin-top: 5px;
+    margin-bottom: 10px;
+}
 #neurosnake-canvas {
     background: #000;
     display: block;


### PR DESCRIPTION
## Summary
- require arrow input to start NeuroSnake
- display score and instructions in the NeuroSnake popup
- implement exponential Psychbuck rewards
- increase game speed at higher scores

## Testing
- `node --check "Universal Psychology/neurosnake.js"`
- `node --check "Universal Psychology/game_logic.js"`


------
https://chatgpt.com/codex/tasks/task_e_6876e9918fc88327acc444db82f4067d