### PR TITLE
Fix NeuroSnake crash before initialization

### DIFF
--- a/Universal Psychology/neurosnake.js
+++ b/Universal Psychology/neurosnake.js
@@ -121,6 +121,8 @@ function gameLoop(){
 }
 
 function draw(){
+    // `resizeCanvas` may call draw before the snake is initialized.
+    if (!snake) return;
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 


### PR DESCRIPTION
## Summary
- prevent draw from running before snake is initialized

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68787fbea8bc83278dce5f8d5bdeefa9