### PR TITLE
Document Universal Paperclips as reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains two small web games along with a supporting React component.
 
+> **Note**: The "Universal Paperclips" folder is included only as a design reference. Active development focuses on the "Universal Psychology" game.
+
 ## Universal Psychology
 
 An incremental browser game focused on building a virtual mind.  Players add neurons, purchase upgrades and watch their consciousness grow.  The project is written in vanilla HTML/JavaScript and can be served as static files.
@@ -18,7 +20,7 @@ Open your browser at <http://localhost:8000> and load `index.html`.
 
 ## Universal Paperclips
 
-A copy of the classic incremental game where you create paperclips until the universe is transformed.  The game is also pure HTML/JavaScript and can be run from a simple static server.
+A copy of the classic incremental game where you create paperclips until the universe is transformed. This directory is provided only as a reference and is not under active development. The game is pure HTML/JavaScript and can be run from a simple static server.
 
 **Serve locally**
 


### PR DESCRIPTION
## Summary
- note that Universal Paperclips folder is included only as a design reference
- clarify Universal Paperclips section isn't under active development

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c21ad98e108327857ffa46a36fbf7b