### PR TITLE
Preserve neuro fuel cost across saves

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -446,7 +446,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function saveGame(slot = currentSaveSlot) {
         const save = {
-            gameState,
+            gameState: { ...gameState },
             coreUpgrades: UpgradeSystem.coreUpgrades,
             proliferationUpgrades: UpgradeSystem.neuronProliferationUpgrades,
             purchasedProjects: gameState.purchasedProjects
@@ -505,8 +505,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         if(!raw) return;
         try {
             const data = JSON.parse(raw);
-            Object.assign(gameState, data.gameState || {});
-            gameState.neuroFuelCost = calculateNextNeuroFuelCost();
+            const savedState = data.gameState || {};
+            Object.assign(gameState, savedState);
+            if (typeof savedState.neuroFuelCost !== 'number') {
+                gameState.neuroFuelCost = calculateNextNeuroFuelCost();
+            }
             if(Array.isArray(data.coreUpgrades)) {
                 data.coreUpgrades.forEach(saved => {
                     const existing = UpgradeSystem.coreUpgrades.find(u => u.id === saved.id);


### PR DESCRIPTION
## Summary
- Save `neuroFuelCost` by storing a copy of the game state during saves
- Load saved `neuroFuelCost` when available and only recalculate if missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c22f9583248327a41c031c8e403080