### PR TITLE
Group stat color selectors

### DIFF
--- a/Universal Psychology/style.css
+++ b/Universal Psychology/style.css
@@ -90,11 +90,10 @@ body {
     font-size: 1.1em;
     font-weight: bold;
 }
-#neurons-display { color: #555; }
-#psychbucks-display { color: #666; }
+/* Colors for stat displays */
+#neurons-display, #neurofuel-display { color: #555; }
+#psychbucks-display, #ops-display { color: #666; }
 #iq-display { color: #767676; }
-#ops-display { color: #666; }
-#neurofuel-display { color: #555; }
 
 /* Icons for stat labels to reduce reliance on color */
 #neurons-display::before { content: "🧠 "; }


### PR DESCRIPTION
## Summary
- Consolidate individual stat color rules in `style.css` into grouped selectors for easier maintenance.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c23a44c5f48327b744fb758fbaeb87