### PR TITLE
Fix brain upgrade animation image path

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -215,11 +215,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             if(openFeedSundgrenBtn) openFeedSundgrenBtn.style.display = gameState.unlockedGames.feedSundgren ? '' : 'none';
         },
         updateSingleUpgradeButton(btnEl,canAfford){if(btnEl)btnEl.disabled=!canAfford;},
-        // Path to brain upgrade image is relative to index.html, which lives
-        // inside the "Universal Psychology" folder. The image itself is stored
-        // in the repository root "images" directory, so the correct relative
-        // path needs to go up one level.
-        playBrainUpgradeAnimation(imgSrc="../images/brain-upgrade.png"){
+        // Path to the brain upgrade image is relative to index.html, which is
+        // inside the "Universal Psychology" folder. The image file resides in
+        // this folder's "images" directory, so no parent navigation is needed.
+        playBrainUpgradeAnimation(imgSrc="images/brain-upgrade.png"){
             const overlay=document.getElementById("upgrade-animation-overlay");
             if(!overlay) return;
             overlay.innerHTML="";


### PR DESCRIPTION
## Summary
- Correct brain upgrade animation image path
- Document image location in UI manager comment

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c23cafc7208327a94981a67d2229b8