### PR TITLE
Prevent orphaned food timers

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -417,6 +417,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         UIManager.logMessage('Intermittent Fasting activated: auto-buy every 10s.', 'log-info');
     }
 
+    function stopIntermittentFasting(){
+        if(!intermittentFastingIntervalId) return;
+        clearInterval(intermittentFastingIntervalId);
+        intermittentFastingIntervalId = null;
+        UIManager.logMessage('Intermittent Fasting stopped.', 'log-info');
+    }
+
     function startIrregularSnacks(){
         if(irregularSnacksTimeoutId) return;
         const schedule = () => {
@@ -428,6 +435,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         };
         schedule();
         UIManager.logMessage('Irregular Snacks activated.', 'log-info');
+    }
+
+    function stopIrregularSnacks(){
+        if(!irregularSnacksTimeoutId) return;
+        clearTimeout(irregularSnacksTimeoutId);
+        irregularSnacksTimeoutId = null;
+        UIManager.logMessage('Irregular Snacks stopped.', 'log-info');
     }
     function handleDopamineSlider(event) { gameState.dopamineLevel = parseInt(event.target.value); if(dopamineLevelDisplayDOM) dopamineLevelDisplayDOM.textContent = gameState.dopamineLevel; UIManager.callUpdateBrainVisual(); UIManager.updateAllDisplays(); }
     function handleGabaSlider(event) { gameState.gabaLevel = parseInt(event.target.value); if(gabaLevelDisplayDOM) gabaLevelDisplayDOM.textContent = gameState.gabaLevel; UIManager.callUpdateBrainVisual(); UIManager.updateAllDisplays(); }
@@ -512,6 +526,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function loadGame(slot = currentSaveSlot) {
+        stopIntermittentFasting();
+        stopIrregularSnacks();
         const raw = localStorage.getItem(`up_save_${slot}`);
         if(!raw){ ProjectSystem.renderProjects(); return; }
         try {
@@ -540,6 +556,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function resetGame(slot = currentSaveSlot) {
+        stopIntermittentFasting();
+        stopIrregularSnacks();
         localStorage.removeItem(`up_save_${slot}`);
         location.reload();
     }


### PR DESCRIPTION
## Summary
- add stopIntermittentFasting and stopIrregularSnacks to clear their timers
- ensure loadGame resets timers and restarts them only if upgrade exists
- halt timers during game reset to prevent orphaned intervals

## Testing
- `node --check "Universal Psychology/game_logic.js"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c23cae494c83279611ba36ce42d1d5