### PR TITLE
feat: add language manager for log styling

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -1,4 +1,5 @@
 // game_logic.js
+import LanguageManager from './language.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     // --- 1. GAME STATE OBJECT ---
@@ -76,7 +77,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if(typeof p.effect === 'function') p.effect.call(p);
             p.purchased = true;
             gameState.purchasedProjects.push(id);
-            UIManager.logMessage(`Project completed: ${p.title}`, 'log-upgrade');
+            UIManager.logMessage(LanguageManager.log('projectCompleted', {title: p.title}), 'log-upgrade');
             this.renderProjects();
             UIManager.updateAllDisplays();
         },
@@ -391,7 +392,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     function handleManualGeneration() {
         if (AnxietySystem.isAttackCurrentlyActive()) { UIManager.logMessage("Brain recovering... clicking disabled (Anxiety Active).", "log-warning"); return; }
         const possible = Math.min(gameState.neuronsPerClick, gameState.neuroFuel / gameState.manualFuelMultiplier);
-        if(possible <= 0){ UIManager.logMessage('Out of NeuroFuel!', 'log-warning'); return; }
+        if(possible <= 0){ UIManager.logMessage(LanguageManager.log('outOfNeuroFuel'), 'log-warning'); return; }
         let neuronsBeforeClick = gameState.neurons; gameState.neurons += possible; gameState.totalNeuronsGenerated += possible;
         gameState.mindOps += possible * OPS_PER_NEURON;
         gameState.neuroFuel -= possible * gameState.manualFuelMultiplier;
@@ -413,7 +414,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             UIManager.logMessage(`Proliferation Factory purchased! Total: ${gameState.factoryCount}`, 'log-upgrade');
             ProjectSystem.renderProjects();
         } else {
-            UIManager.logMessage('Not enough Psychbucks for factory.', 'log-warning');
+            UIManager.logMessage(LanguageManager.log('notEnoughPsychbucks', {item: 'factory'}), 'log-warning');
         }
         UIManager.updateAllDisplays();
         UpgradeSystem.renderNeuronProliferationUpgrades();
@@ -427,7 +428,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             UIManager.logMessage(`Purchased ${item.emoji} ${item.name}! (+${item.fuel} Fuel)`, 'log-upgrade');
             gameState.neuroFuelCost = calculateNextNeuroFuelCost();
         } else {
-            UIManager.logMessage('Not enough Psychbucks for food.', 'log-warning');
+            UIManager.logMessage(LanguageManager.log('notEnoughPsychbucks', {item: 'food'}), 'log-warning');
         }
         UIManager.updateAllDisplays();
     }

--- a/Universal Psychology/language.js
+++ b/Universal Psychology/language.js
@@ -1,0 +1,39 @@
+const LanguageManager = (() => {
+  let level = 2; // default normal tone
+  const templates = {
+    projectCompleted: [
+      'Rock done! {title}',
+      'We finished the thing! {title}',
+      'Project completed: {title}',
+      'Our endeavor has reached fruition: {title}'
+    ],
+    notEnoughPsychbucks: [
+      "Broke: can't pay for {item}.",
+      "We can't afford {item}.",
+      "Not enough Psychbucks for {item}.",
+      "Our coffers are insufficient for {item}."
+    ],
+    outOfNeuroFuel: [
+      'Bone dry on NeuroFuel!',
+      'Fuel tanks empty!',
+      'Out of NeuroFuel!',
+      'Our reserves of NeuroFuel have been depleted.'
+    ],
+    neuroSnakeFinished: [
+      'Snake score! +{score} PB!',
+      'Serpent success nets {score} bucks!',
+      'NeuroSnake finished: +{score} Psychbucks!',
+      'Our serpent crusade yields {score} Psychbucks.'
+    ]
+  };
+  const replaceParams = (str, params = {}) => str.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? '');
+  return {
+    setLevel: l => { level = Math.max(0, Math.min(3, l)); },
+    log: (key, params = {}, fallback = '') => {
+      const entry = templates[key];
+      if (entry) return replaceParams(entry[Math.min(level, entry.length - 1)], params);
+      return replaceParams(fallback || key, params);
+    }
+  };
+})();
+export default LanguageManager;

--- a/Universal Psychology/neurosnake.js
+++ b/Universal Psychology/neurosnake.js
@@ -1,4 +1,5 @@
 // neurosnake.js - enhanced snake variant rewarding Psychbucks
+import LanguageManager from './language.js';
 
 // Grid size and cell dimension will be adjusted dynamically
 let cellSize = 30;
@@ -256,7 +257,7 @@ function endGame(){
         const gs = api.getGameState();
         gs.psychbucks += score;
         api.updateDisplays();
-        api.logMessage(`NeuroSnake finished: +${score} Psychbucks!`, 'log-info');
+        api.logMessage(LanguageManager.log('neuroSnakeFinished', {score}), 'log-info');
     }
     if(instructionDisplay) instructionDisplay.textContent = 'Game over';
 }


### PR DESCRIPTION
## Summary
- add LanguageManager with tone-based log templates
- use LanguageManager for project completion and common resource warnings
- apply language styling to NeuroSnake minigame logs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c358a2b91883278a04aebc6c2cfeb1