### PR TITLE
feat: expand language manager with levels

### DIFF
--- a/Universal Psychology/language_manager.js
+++ b/Universal Psychology/language_manager.js
@@ -1,27 +1,99 @@
 export const LanguageManager = {
   phrases: {
-    addNeurons: ["Add Neurons", "Grow Neurons", "Engineer Neurons", "Forge Neurons"],
-    testYourKnowledge: ["Test Your Knowledge", "Challenge Your Mind", "Probe Your Psyche", "Master The Mind"],
-    neuroGames: ["NeuroGames", "Mind Games", "Cognitive Games", "Psyche Arcade"],
-    yourBrain: ["Your Brain", "Your Mind", "Your Cortex", "Your Consciousness"],
-    coreUpgrades: ["Core Upgrades", "Brain Upgrades", "Neural Enhancements", "Cognitive Enhancements"],
-    proliferationFactories: ["Proliferation Factories", "Neuron Forges", "Synapse Labs", "Cerebral Foundries"],
-    buyFactory: ["Buy Proliferation Factory", "Buy Neuron Forge", "Buy Synapse Lab", "Buy Cerebral Foundry"],
-    neuronProliferation: ["Neuron Proliferation", "Neuron Expansion", "Synapse Expansion", "Cerebral Multiplication"],
-    neurofuel: ["NeuroFuel", "NeuroFuel", "Cognitive Fuel", "Psyche Fuel"],
-    buyFood: ["Buy Food", "Purchase Fuel", "Acquire Nourishment", "Procure Sustenance"],
-    projects: ["Projects", "Initiatives", "Research Projects", "Grand Experiments"],
-    hypothalamusControls: ["Hypothalamus Controls", "Hypothalamus Interface", "Limbic Controls", "Autonomic Interface"],
-    dopamine: ["Dopamine:", "Dopamine:", "Dopamine:", "Dopamine:"],
-    gaba: ["GABA:", "GABA:", "GABA:", "GABA:"]
+    addNeurons: [
+      "Make Brain Bits",
+      "Grow Neuron Buds",
+      "Add Neurons",
+      "Initiate Neuronal Augmentation"
+    ],
+    testYourKnowledge: [
+      "Brain Test",
+      "Quiz Time",
+      "Test Your Knowledge",
+      "Assess Cognitive Aptitude"
+    ],
+    neuroGames: [
+      "Brain Fun",
+      "Mind Games",
+      "NeuroGames",
+      "Cerebral Recreations"
+    ],
+    yourBrain: [
+      "Your Brain",
+      "Your Mind",
+      "Your Cortex",
+      "Your Consciousness"
+    ],
+    coreUpgrades: [
+      "Brain Boosts",
+      "Mind Upgrades",
+      "Core Upgrades",
+      "Cognitive Enhancements"
+    ],
+    proliferationFactories: [
+      "Brain Makers",
+      "Neuron Forges",
+      "Proliferation Factories",
+      "Cerebral Foundries"
+    ],
+    buyFactory: [
+      "Get Brain Maker",
+      "Buy Neuron Forge",
+      "Buy Proliferation Factory",
+      "Procure Cerebral Foundry"
+    ],
+    neuronProliferation: [
+      "More Brain Bits",
+      "Neuron Growth",
+      "Neuron Proliferation",
+      "Cerebral Multiplication"
+    ],
+    neurofuel: [
+      "Brain Fuel",
+      "Neuron Juice",
+      "NeuroFuel",
+      "Cognitive Fuel"
+    ],
+    buyFood: [
+      "Get Food",
+      "Buy Snacks",
+      "Buy Food",
+      "Procure Sustenance"
+    ],
+    projects: [
+      "Brain Plans",
+      "Big Projects",
+      "Projects",
+      "Grand Experiments"
+    ],
+    hypothalamusControls: [
+      "Brain Buttons",
+      "Hypothalamus Buttons",
+      "Hypothalamus Controls",
+      "Autonomic Interface"
+    ],
+    dopamine: [
+      "Happy Juice:",
+      "Feel-Good Chemical:",
+      "Dopamine:",
+      "Dopaminergic Concentration:"
+    ],
+    gaba: [
+      "Calm Juice:",
+      "Chill Chemical:",
+      "GABA:",
+      "Gamma-Aminobutyric Acid:"
+    ]
   },
-  apply(level = 0) {
+  getPhrase(key, level = 2, params = {}) {
+    const variants = this.phrases[key];
+    let phrase = variants ? (variants[level] ?? variants[2]) : "";
+    return phrase.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`);
+  },
+  apply(level = 2) {
     document.querySelectorAll('[data-lang-key]').forEach(el => {
       const key = el.getAttribute('data-lang-key');
-      const variants = this.phrases[key];
-      if (variants) {
-        el.textContent = variants[level] || variants[0];
-      }
+      el.textContent = this.getPhrase(key, level);
     });
   }
 };


### PR DESCRIPTION
## Summary
- add caveman/child/normal/complex variants for all language keys
- introduce `getPhrase` helper with optional params
- update `apply` to use new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c780204bdc832786af5c8f03be448d