### PR TITLE
Localize stat displays with LanguageManager

### DIFF
--- a/Universal Psychology/game_logic.js
+++ b/Universal Psychology/game_logic.js
@@ -210,11 +210,50 @@ document.addEventListener('DOMContentLoaded', async () => {
     // --- 5. UI MANAGER OBJECT ---
     const UIManager = {
         logMessage(message, type = 'log-info') { if (!infoBannerDOM) return; while (infoBannerDOM.childNodes.length >= MAX_LOG_MESSAGES) { infoBannerDOM.removeChild(infoBannerDOM.lastChild); } const el = document.createElement('p'); el.textContent = `[${new Date().toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'})}] ${message}`; el.className = type; infoBannerDOM.insertBefore(el, infoBannerDOM.firstChild); infoBannerDOM.scrollTop = 0; },
-        updateNeuronDisplay() { if (neuronsDisplayDOM) { neuronsDisplayDOM.textContent = `Neurons: ${Math.floor(gameState.neurons)}`; } },
-        updatePsychbuckDisplay(rate) { if (psychbucksDisplayDOM) psychbucksDisplayDOM.textContent = `Psychbucks: ${Math.floor(gameState.psychbucks)} | Passive: ${rate.toFixed(1)}/s`; },
-        updateOpsDisplay() { if (opsDisplayDOM) opsDisplayDOM.textContent = `Ops: ${Math.floor(gameState.mindOps)}`; },
-        updateIQDisplay() { if (iqDisplayDOM) { const act = gameState.totalNeuronsGenerated + gameState.neuronsSpentOnBrainUpgrades + 1; const iq = BASE_IQ + Math.log10(act) * IQ_SCALE_FACTOR; iqDisplayDOM.textContent = `IQ: ${Math.floor(iq)}`; } },
-        updateNeuroFuelDisplay() { if (neurofuelCountDOM && neurofuelCostDOM) { neurofuelCountDOM.textContent = Math.floor(gameState.neuroFuel); neurofuelCostDOM.textContent = Math.ceil(gameState.neuroFuelCost); } if(buyNeurofuelBtnDOM) buyNeurofuelBtnDOM.disabled = gameState.psychbucks < gameState.neuroFuelCost; if(document.getElementById('neurofuel-display')) document.getElementById('neurofuel-display').textContent = `Fuel: ${Math.floor(gameState.neuroFuel)}`; },
+        updateNeuronDisplay() {
+            if (neuronsDisplayDOM) {
+                neuronsDisplayDOM.textContent = LanguageManager.getPhrase('stats.neurons', gameState.currentBrainLevel, {
+                    value: Math.floor(gameState.neurons)
+                });
+            }
+        },
+        updatePsychbuckDisplay(rate) {
+            if (psychbucksDisplayDOM) {
+                psychbucksDisplayDOM.textContent = LanguageManager.getPhrase('stats.psychbucks', gameState.currentBrainLevel, {
+                    value: Math.floor(gameState.psychbucks),
+                    rate: rate.toFixed(1)
+                });
+            }
+        },
+        updateOpsDisplay() {
+            if (opsDisplayDOM) {
+                opsDisplayDOM.textContent = LanguageManager.getPhrase('stats.ops', gameState.currentBrainLevel, {
+                    value: Math.floor(gameState.mindOps)
+                });
+            }
+        },
+        updateIQDisplay() {
+            if (iqDisplayDOM) {
+                const act = gameState.totalNeuronsGenerated + gameState.neuronsSpentOnBrainUpgrades + 1;
+                const iq = BASE_IQ + Math.log10(act) * IQ_SCALE_FACTOR;
+                iqDisplayDOM.textContent = LanguageManager.getPhrase('stats.iq', gameState.currentBrainLevel, {
+                    value: Math.floor(iq)
+                });
+            }
+        },
+        updateNeuroFuelDisplay() {
+            if (neurofuelCountDOM && neurofuelCostDOM) {
+                neurofuelCountDOM.textContent = Math.floor(gameState.neuroFuel);
+                neurofuelCostDOM.textContent = Math.ceil(gameState.neuroFuelCost);
+            }
+            if (buyNeurofuelBtnDOM) buyNeurofuelBtnDOM.disabled = gameState.psychbucks < gameState.neuroFuelCost;
+            const fuelDisplayDOM = document.getElementById('neurofuel-display');
+            if (fuelDisplayDOM) {
+                fuelDisplayDOM.textContent = LanguageManager.getPhrase('stats.fuel', gameState.currentBrainLevel, {
+                    value: Math.floor(gameState.neuroFuel)
+                });
+            }
+        },
         updateAnxietyDisplay() { if (!anxietyStatusDisplayDOM) return; const ax = AnxietySystem.getAnxietyInfo(); let txt = `Anxiety: Normal (${ax.meter.toFixed(0)}%)`, clr = "green"; if (ax.isAttackActive){txt="Status: ANXIETY ATTACK!";clr="red";} else if (ax.activeStimuliCount>0 && ax.isAmygdalaSystemActive){txt=`Anxiety: Stimuli! (${ax.meter.toFixed(0)}%)`;clr="purple";} else if (ax.meter>ANXIETY_SUSTAINED_THRESHOLD){txt=`Anxiety: CRITICAL (${ax.meter.toFixed(0)}%)`;clr="orange";} else if (ax.meter>ANXIETY_SUSTAINED_THRESHOLD/2){txt=`Anxiety: Elevated (${ax.meter.toFixed(0)}%)`;clr="#CCCC00";} else if (ax.meter>0){txt=`Anxiety: Moderate (${ax.meter.toFixed(0)}%)`;clr="yellowgreen";} anxietyStatusDisplayDOM.textContent=txt; anxietyStatusDisplayDOM.style.color=clr;},
         updateQuestionAreaUIVisibility() { if (!questionAreaSectionDOM) {this.logMessage("Q Area DOM missing!","log-warning"); return;} if(gameState.questionsActuallyUnlocked){questionAreaSectionDOM.style.display='';this.logMessage("Q area VISIBLE.","log-info"); if(QuestionSystem.getCurrentQuestionIndex()===-1){this.logMessage("UIManager: Triggering QS loadNextQ.","log-info");QuestionSystem.loadNextQuestion();}}else{questionAreaSectionDOM.style.display='none';if(questionTextElementDOM)questionTextElementDOM.textContent="Upgrade brain for Qs.";if(answerOptionsElementDOM)answerOptionsElementDOM.innerHTML='';this.clearFeedbackAreas();this.logMessage("Q area HIDDEN.","log-info");}},
         displayQuestion(qData) {

--- a/Universal Psychology/language_manager.js
+++ b/Universal Psychology/language_manager.js
@@ -83,10 +83,42 @@ export const LanguageManager = {
       "Chill Chemical:",
       "GABA:",
       "Gamma-Aminobutyric Acid:"
-    ]
+    ],
+    stats: {
+      neurons: [
+        "Neurons: {value}",
+        "Brain Bits: {value}",
+        "Neurons: {value}",
+        "Cortical Units: {value}"
+      ],
+      psychbucks: [
+        "Psychbucks: {value} | Passive: {rate}/s",
+        "Mind Money: {value} | Passive: {rate}/s",
+        "Psychbucks: {value} | Passive: {rate}/s",
+        "Cerebral Cash: {value} | Passive: {rate}/s"
+      ],
+      ops: [
+        "Ops: {value}",
+        "Mind Ops: {value}",
+        "Ops: {value}",
+        "Cognitive Ops: {value}"
+      ],
+      iq: [
+        "IQ: {value}",
+        "Brain Power: {value}",
+        "IQ: {value}",
+        "Intellect: {value}"
+      ],
+      fuel: [
+        "Fuel: {value}",
+        "Brain Fuel: {value}",
+        "Fuel: {value}",
+        "Cognitive Fuel: {value}"
+      ]
+    }
   },
   getPhrase(key, level = 2, params = {}) {
-    const variants = this.phrases[key];
+    const variants = key.split('.').reduce((obj, k) => (obj && obj[k]) ? obj[k] : undefined, this.phrases);
     let phrase = variants ? (variants[level] ?? variants[2]) : "";
     return phrase.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`);
   },
@@ -95,5 +127,8 @@ export const LanguageManager = {
       const key = el.getAttribute('data-lang-key');
       el.textContent = this.getPhrase(key, level);
     });
+    if (window.GameAPI && typeof window.GameAPI.updateDisplays === 'function') {
+      window.GameAPI.updateDisplays();
+    }
   }
 };


### PR DESCRIPTION
## Summary
- Use LanguageManager templates for neuron, psychbuck, ops, IQ, and fuel displays
- Extend LanguageManager with stat phrases and nested key lookup
- Refresh stat displays when LanguageManager.apply is called

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c784b0ccc08327b3143aa883d76fae