### PR TITLE
Improve language manager upgrade phrases

### DIFF
--- a/Universal Psychology/language_manager.js
+++ b/Universal Psychology/language_manager.js
@@ -115,12 +115,111 @@ export const LanguageManager = {
         "Fuel: {value}",
         "Cognitive Fuel: {value}"
       ]
+    },
+    upgrades: {
+      brainGrowth1: {
+        name: "Brain Growth: Stage 1",
+        desc: "Unlocks EASY Qs & Neuron Proliferation."
+      },
+      brainGrowth2: {
+        name: "Brain Growth: Stage 2",
+        desc: "Unlocks MEDIUM Qs & Hypothalamus."
+      },
+      brainGrowth3: {
+        name: "Brain Growth: Stage 3",
+        desc: "Unlocks HARD Qs & Amygdala research."
+      },
+      amygdalaActivation: {
+        name: [
+          "Activate Amygdala",
+          "Amygdala Surge",
+          "Activate Amygdala",
+          "Amygdala Override"
+        ],
+        desc: [
+          "Doubles passive neuron production. WARNING: Random stimuli.",
+          "Hypercharges neuron flow; expect heightened emotional stimuli.",
+          "Doubles passive neuron production. Brace for unpredictable triggers.",
+          "Reroutes limbic output for massive gains with severe volatility."
+        ]
+      },
+      nucleusAccumbens: {
+        name: [
+          "Nucleus Accumbens",
+          "Reward Center Expansion",
+          "Nucleus Accumbens",
+          "Pleasure Circuit Dominion"
+        ],
+        desc: [
+          "Unlocks access to NeuroGames.",
+          "Opens the pleasure hub—NeuroGames now available.",
+          "Unlocks access to NeuroGames and new dopamine pathways.",
+          "Throws open the reward nexus for advanced NeuroGames."
+        ]
+      },
+      biggerBrain1: {
+        name: "Brain Growth: Stage 1",
+        desc: "Unlocks EASY Qs & Neuron Proliferation."
+      },
+      biggerBrain2: {
+        name: "Brain Growth: Stage 2",
+        desc: "Unlocks MEDIUM Qs & Hypothalamus."
+      },
+      biggerBrain3: {
+        name: "Brain Growth: Stage 3",
+        desc: "Unlocks HARD Qs & Amygdala research."
+      },
+      prolifFactory: {
+        name: "Neuron Proliferation Factory",
+        desc: "Builds a facility for passive neuron growth (+0.5/sec)."
+      },
+      dendriticSprouting: {
+        name: "Dendritic Sprouting",
+        desc: "Increase passive neuron production by 0.1%."
+      },
+      myelination: {
+        name: "Myelination",
+        desc: "Boost production but consumes more fuel and raises anxiety."
+      },
+      metabolicEfficiency: {
+        name: "Metabolic Efficiency",
+        desc: "Cuts Neurofuel consumption by 50%."
+      },
+      intermittentFasting: {
+        name: "Intermittent Fasting",
+        desc: "Automatically purchase fuel every 10 seconds."
+      },
+      metabolicEfficiency2: {
+        name: "Metabolic Efficiency II",
+        desc: "Further cuts fuel use by 50%."
+      }
     }
   },
   getPhrase(key, level = 2, params = {}) {
-    const variants = key.split('.').reduce((obj, k) => (obj && obj[k]) ? obj[k] : undefined, this.phrases);
-    let phrase = variants ? (variants[level] ?? variants[2]) : "";
-    return phrase.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`);
+    const path = key.split('.');
+    let value = this.phrases;
+
+    for (const segment of path) {
+      if (value == null || (typeof value !== 'object' && !Array.isArray(value))) {
+        value = undefined;
+        break;
+      }
+      value = value[segment];
+    }
+
+    if (Array.isArray(value)) {
+      const fallbackIndex = Math.min(2, Math.max(0, value.length - 1));
+      const phraseCandidate = value[level] ?? value[fallbackIndex] ?? value[value.length - 1] ?? '';
+      return typeof phraseCandidate === 'string'
+        ? phraseCandidate.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`)
+        : '';
+    }
+
+    if (typeof value === 'string') {
+      return value.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`);
+    }
+
+    return '';
   },
   apply(level = 2) {
     document.querySelectorAll('[data-lang-key]').forEach(el => {


### PR DESCRIPTION
## Summary
- add localized upgrade phrases including single-string values for non-varying entries
- extend LanguageManager.getPhrase to support both string and array phrase definitions

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb4132b8d8832780dc767c74ef3f19