### PR TITLE
Localize upgrade text across brain levels

### DIFF
--- a/Universal Psychology/language_manager.js
+++ b/Universal Psychology/language_manager.js
@@ -118,16 +118,46 @@ export const LanguageManager = {
     },
     upgrades: {
       brainGrowth1: {
-        name: "Brain Growth: Stage 1",
-        desc: "Unlocks EASY Qs & Neuron Proliferation."
+        name: [
+          "Brain Make Big",
+          "Brain Booster Level 1",
+          "Brain Growth: Stage 1",
+          "Neocortex Initiation I"
+        ],
+        desc: [
+          "Open easy think rocks. Get more brain bits.",
+          "Unlock easy questions and basic neuron making.",
+          "Unlocks EASY Qs & Neuron Proliferation.",
+          "Bootstraps foundational cognition and neuron forges."
+        ]
       },
       brainGrowth2: {
-        name: "Brain Growth: Stage 2",
-        desc: "Unlocks MEDIUM Qs & Hypothalamus."
+        name: [
+          "Brain Make Bigger",
+          "Brain Booster Level 2",
+          "Brain Growth: Stage 2",
+          "Neocortex Initiation II"
+        ],
+        desc: [
+          "Open medium brain trials. Poke feeling gland.",
+          "Unlock medium questions and Hypothalamus controls.",
+          "Unlocks MEDIUM Qs & Hypothalamus.",
+          "Extends cognitive bandwidth and autonomic command hub."
+        ]
       },
       brainGrowth3: {
-        name: "Brain Growth: Stage 3",
-        desc: "Unlocks HARD Qs & Amygdala research."
+        name: [
+          "Brain Biggest Now",
+          "Brain Booster Level 3",
+          "Brain Growth: Stage 3",
+          "Neocortex Initiation III"
+        ],
+        desc: [
+          "Open hard mind fire. Start fear study.",
+          "Unlock hard questions and amygdala research.",
+          "Unlocks HARD Qs & Amygdala research.",
+          "Deploy elite cognition and limbic experimentation."
+        ]
       },
       amygdalaActivation: {
         name: [
@@ -158,46 +188,158 @@ export const LanguageManager = {
         ]
       },
       biggerBrain1: {
-        name: "Brain Growth: Stage 1",
-        desc: "Unlocks EASY Qs & Neuron Proliferation."
+        name: [
+          "Brain Make Big",
+          "Brain Booster Level 1",
+          "Brain Growth: Stage 1",
+          "Neocortex Initiation I"
+        ],
+        desc: [
+          "Open easy think rocks. Get more brain bits.",
+          "Unlock easy questions and basic neuron making.",
+          "Unlocks EASY Qs & Neuron Proliferation.",
+          "Bootstraps foundational cognition and neuron forges."
+        ]
       },
       biggerBrain2: {
-        name: "Brain Growth: Stage 2",
-        desc: "Unlocks MEDIUM Qs & Hypothalamus."
+        name: [
+          "Brain Make Bigger",
+          "Brain Booster Level 2",
+          "Brain Growth: Stage 2",
+          "Neocortex Initiation II"
+        ],
+        desc: [
+          "Open medium brain trials. Poke feeling gland.",
+          "Unlock medium questions and Hypothalamus controls.",
+          "Unlocks MEDIUM Qs & Hypothalamus.",
+          "Extends cognitive bandwidth and autonomic command hub."
+        ]
       },
       biggerBrain3: {
-        name: "Brain Growth: Stage 3",
-        desc: "Unlocks HARD Qs & Amygdala research."
+        name: [
+          "Brain Biggest Now",
+          "Brain Booster Level 3",
+          "Brain Growth: Stage 3",
+          "Neocortex Initiation III"
+        ],
+        desc: [
+          "Open hard mind fire. Start fear study.",
+          "Unlock hard questions and amygdala research.",
+          "Unlocks HARD Qs & Amygdala research.",
+          "Deploy elite cognition and limbic experimentation."
+        ]
       },
       prolifFactory: {
-        name: "Neuron Proliferation Factory",
-        desc: "Builds a facility for passive neuron growth (+0.5/sec)."
+        name: [
+          "Brain Hut",
+          "Neuron Workshop",
+          "Neuron Proliferation Factory",
+          "Cortical Multiplex Forge"
+        ],
+        desc: [
+          "Build hut make brain bits drip (+0.5/sec).",
+          "Construct a workshop for steady neuron flow (+0.5/sec).",
+          "Builds a facility for passive neuron growth (+0.5/sec).",
+          "Deploys an auto-synaptic manufactory (+0.5/sec)."
+        ]
       },
       dendriticSprouting: {
-        name: "Dendritic Sprouting",
-        desc: "Increase passive neuron production by 0.1%."
+        name: [
+          "Branchy Brain",
+          "Neuron Branch Party",
+          "Dendritic Sprouting",
+          "Fractal Synapse Bloom"
+        ],
+        desc: [
+          "Little branches grow. More brain slow (+0.1%).",
+          "New dendrite branches boost passive gain (+0.1%).",
+          "Increase passive neuron production by 0.1%.",
+          "Micro arborization optimizes passive throughput (+0.1%)."
+        ]
       },
       myelination: {
-        name: "Myelination",
-        desc: "Boost production but consumes more fuel and raises anxiety."
+        name: [
+          "Brain Goo Wrap",
+          "Neuron Speed Shell",
+          "Myelination",
+          "Quantum Axon Sheathing"
+        ],
+        desc: [
+          "Wrap axon fast. Need more juice, raise jitters.",
+          "Coat neurons for speed, costs extra fuel and nerves.",
+          "Boost production but consumes more fuel and raises anxiety.",
+          "Phase-shift conduits for hyper output; fuel and anxiety spike."
+        ]
       },
       metabolicEfficiency: {
-        name: "Metabolic Efficiency",
-        desc: "Cuts Neurofuel consumption by 50%."
+        name: [
+          "Less Fuel Hungry",
+          "Metabolism Makeover",
+          "Metabolic Efficiency",
+          "Bioenergetic Harmonizer"
+        ],
+        desc: [
+          "Brain sip slow. Fuel last double.",
+          "Teach body to sip fuel gently (50% cut).",
+          "Cuts Neurofuel consumption by 50%.",
+          "Optimizes biofuel routing for half consumption."
+        ]
       },
       intermittentFasting: {
-        name: "Intermittent Fasting",
-        desc: "Automatically purchase fuel every 10 seconds."
+        name: [
+          "Brain Wait Eat",
+          "Scheduled Snack Time",
+          "Intermittent Fasting",
+          "Chrono-Fuel Autopilot"
+        ],
+        desc: [
+          "Magic food buy self sometimes.",
+          "Auto-purchase fuel snack every ten seconds.",
+          "Automatically purchase fuel every 10 seconds.",
+          "Temporal procurement bot schedules fuel injections."
+        ]
       },
       metabolicEfficiency2: {
-        name: "Metabolic Efficiency II",
-        desc: "Further cuts fuel use by 50%."
-      }
+        name: [
+          "Fuel Saver Supreme",
+          "Metabolism Mastery",
+          "Metabolic Efficiency II",
+          "Bioenergetic Singularity"
+        ],
+        desc: [
+          "Fuel barely gone now.",
+          "Cut fuel drain again—super efficient!",
+          "Further cuts fuel use by 50%.",
+          "Compress consumption to negligible flux."
+        ]
+      },
+      notEnough: [
+        "No have enough for {name}.",
+        "Not enough saved for {name} yet.",
+        "Not enough for {name}.",
+        "Insufficient resources for {name}."
+      ]
     }
   },
   getPhrase(key, level = 2, params = {}) {
     const path = key.split('.');
     let value = this.phrases;
+
+    const formatString = str =>
+      (str ?? '').replace(/\{(\w+)\}/g, (_, k) => (params[k] ?? `{${k}}`));
+
+    const resolveVariant = variants => {
+      if (Array.isArray(variants)) {
+        if (variants.length === 0) return '';
+        const fallbackIndex = Math.min(2, Math.max(0, variants.length - 1));
+        const candidate = variants[level] ?? variants[fallbackIndex] ?? variants[variants.length - 1] ?? '';
+        return typeof candidate === 'string' ? formatString(candidate) : '';
+      }
+      if (typeof variants === 'string') {
+        return formatString(variants);
+      }
+      return '';
+    };
 
     for (const segment of path) {
       if (value == null || (typeof value !== 'object' && !Array.isArray(value))) {
@@ -207,16 +349,26 @@ export const LanguageManager = {
       value = value[segment];
     }
 
-    if (Array.isArray(value)) {
-      const fallbackIndex = Math.min(2, Math.max(0, value.length - 1));
-      const phraseCandidate = value[level] ?? value[fallbackIndex] ?? value[value.length - 1] ?? '';
-      return typeof phraseCandidate === 'string'
-        ? phraseCandidate.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`)
-        : '';
+    if (Array.isArray(value) || typeof value === 'string') {
+      return resolveVariant(value);
     }
 
-    if (typeof value === 'string') {
-      return value.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`);
+    if (value && typeof value === 'object') {
+      const result = {};
+      let hasResolvableProp = false;
+      for (const [prop, propValue] of Object.entries(value)) {
+        if (Array.isArray(propValue) || typeof propValue === 'string') {
+          result[prop] = resolveVariant(propValue);
+          hasResolvableProp = true;
+        } else {
+          result[prop] = propValue;
+        }
+      }
+      if (hasResolvableProp) {
+        if ('name' in result) result.name = result.name || '';
+        if ('desc' in result) result.desc = result.desc || '';
+        return result;
+      }
     }
 
     return '';


### PR DESCRIPTION
## Summary
- add caveman/child/normal/galaxy variants for every upgrade name and description, plus shared "not enough" copy
- extend LanguageManager.getPhrase to support structured upgrade lookups with graceful fallbacks
- render upgrade UI text and status messages through the localized entries based on the current brain level

## Testing
- npm test
- node /tmp/check_upgrades.js

------
https://chatgpt.com/codex/tasks/task_e_68d49babdcb083278b3335724bab40a0